### PR TITLE
CMake: bump cmake_minimum_required to 3.10, fix for CMake v4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6.0)
+cmake_minimum_required (VERSION 3.10)
 project (collada-dom)
 set( CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE )
 


### PR DESCRIPTION
ref. https://github.com/NixOS/nixpkgs/pull/449740